### PR TITLE
Rundeck password

### DIFF
--- a/recipes/auth_key.rb
+++ b/recipes/auth_key.rb
@@ -58,11 +58,9 @@ when 'windows'
     not_if            "Test-Path cert:LocalMachine/Root/#{thumbprint}"
   end
 
-  file_resource_name = "file[#{node['rundeck_node']['user_password_file']}]"
-  pwd_file_content = resources(file_resource_name).content if resources.include? file_resource_name
   winrm_config_service_certmapping node['rundeck_node']['user'] do
     username      node['rundeck_node']['user']
-    password      node['rundeck_node']['user_password'] || pwd_file_content
+    password      node['rundeck_node']['user_password'] || node.run_state['rundeck_user_password']
     issuer        thumbprint
     subject       '*'
     uri           '*'

--- a/recipes/local_user.rb
+++ b/recipes/local_user.rb
@@ -29,6 +29,9 @@ if node['rundeck_node']['user_password_file']
     user_pwd = secure_password
   end
 
+  # store the password in run_state for future use
+  node.run_state['rundeck_user_password'] = user_pwd
+
   file node['rundeck_node']['user_password_file'] do
     content        user_pwd
     backup         false

--- a/recipes/local_user.rb
+++ b/recipes/local_user.rb
@@ -35,8 +35,14 @@ if node['rundeck_node']['user_password_file']
   file node['rundeck_node']['user_password_file'] do
     content        user_pwd
     backup         false
-    owner          'LocalSystem'
-    mode           '0600'
+    case node['os']
+    when 'linux'
+      owner        root
+      mode         '0600'
+    when 'windows'
+      inherits     false
+      rights       :full_control, 'SYSTEM'
+    end
   end
 end
 

--- a/spec/recipes/auth_key_spec.rb
+++ b/spec/recipes/auth_key_spec.rb
@@ -2,31 +2,18 @@ require 'spec_helper'
 
 describe 'rundeck-node::auth_key' do
 
-  let(:linux_chef_run) { ChefSpec::SoloRunner.new.converge(described_recipe) }
-
   describe 'on windows' do
-    let(:windows_chef_run) do
-      allow(Chef::Config).to receive(:[]).and_call_original
-      allow(Chef::Config).to receive(:[]).with('file_cache_path').and_return('')
-      expect(OpenSSL::X509::Certificate).to receive(:new).and_return double('new certificate', to_der: 'DER_CERT')
-      expect(Digest::SHA1).to receive(:hexdigest).with('DER_CERT').and_return('0123456789ABCDEF')
-      stub_command('Test-Path cert:LocalMachine/Root/0123456789ABCDEF').and_return(false)
-      ChefSpec::SoloRunner.new(WINDOWS_OHAI) do |node|
-        node.set['rundeck_node']['user_password_file'] = 'dummy_file'
-        node.set['rundeck_node']['auth_public_key'] = 'PUBLIC_KEY_CONTENT'
-      end.converge described_recipe
-    end
 
     it 'stores the public key in the cache folder' do
-      expect(windows_chef_run).to create_file('/rundeck.pem').with(content: 'PUBLIC_KEY_CONTENT')
+      expect(windows_chef_run_with_cert(false)).to create_file('/rundeck.pem').with(content: 'PUBLIC_KEY_CONTENT')
     end
 
     it 'imports the public key in the LocalMachine\Root store' do
-      expect(windows_chef_run).to run_execute('Import public key into LocalMachine\Root')
+      expect(windows_chef_run_with_cert(false)).to run_execute('Import public key into LocalMachine\Root')
     end
 
     it 'configures winrm certmapping' do
-      expect(windows_chef_run).to configure_winrm_config_service_certmapping('rundeck')
+      expect(windows_chef_run_with_cert(false)).to configure_winrm_config_service_certmapping('rundeck')
           .with({
             username: 'rundeck',
             password: nil,
@@ -38,6 +25,8 @@ describe 'rundeck-node::auth_key' do
   end
 
   describe 'on linux' do
+    let(:linux_chef_run) { ChefSpec::SoloRunner.new.converge(described_recipe) }
+
     it 'creates .ssh directory' do
       expect(linux_chef_run).to create_directory('/home/rundeck/.ssh')
     end

--- a/spec/recipes/default_spec.rb
+++ b/spec/recipes/default_spec.rb
@@ -2,14 +2,7 @@ require 'spec_helper'
 
 describe 'rundeck-node::default' do
 
-  def windows_chef_run(attributes = {})
-    expect(OpenSSL::X509::Certificate).to receive(:new).and_return double('new certificate', to_der: 'DER_CERT')
-    expect(Digest::SHA1).to receive(:hexdigest).with('DER_CERT').and_return '0123456789ABCDEF'
-    stub_command('Test-Path cert:LocalMachine/Root/0123456789ABCDEF').and_return(true)
-    ChefSpec::SoloRunner.new(WINDOWS_OHAI) do |node|
-      node.set['rundeck_node'] = attributes.merge(user_password_file: 'dummy_file', auth_public_key: 'PUBLIC_KEY_CONTENT')
-    end.converge described_recipe
-  end
+
   def linux_chef_run(attributes = {})
     ChefSpec::SoloRunner.new do |node|
       node.set['rundeck_node'] = attributes
@@ -17,12 +10,12 @@ describe 'rundeck-node::default' do
   end
 
   it 'includes rundeck-node::local_user recipe when account is local' do
-    expect(windows_chef_run(account: 'local')).to include_recipe('rundeck-node::local_user')
+    expect(windows_chef_run_with_cert(true, account: 'local')).to include_recipe('rundeck-node::local_user')
     expect(linux_chef_run(account: 'local')).to include_recipe('rundeck-node::local_user')
   end
 
   it 'includes rundeck-node::auth_key recipe when auth::key is true' do
     expect(linux_chef_run(auth: { key: true })).to include_recipe('rundeck-node::auth_key')
-    expect(windows_chef_run(auth: { key: true })).to include_recipe('rundeck-node::auth_key')
+    expect(windows_chef_run_with_cert(true, auth: { key: true })).to include_recipe('rundeck-node::auth_key')
   end
 end

--- a/spec/recipes/local_user_spec.rb
+++ b/spec/recipes/local_user_spec.rb
@@ -2,8 +2,14 @@ require 'spec_helper'
 
 describe 'rundeck-node::local_user' do
 
-  let(:windows_chef_run) { ChefSpec::SoloRunner.new(WINDOWS_OHAI).converge(described_recipe) }
-  let(:linux_chef_run) { ChefSpec::SoloRunner.new.converge(described_recipe) }
+  let(:windows_chef_run) do
+    windows_file_rights_hack
+    ChefSpec::SoloRunner.new(WINDOWS_OHAI).converge(described_recipe)
+  end
+
+  let(:linux_chef_run) do
+    ChefSpec::SoloRunner.new.converge(described_recipe)
+  end
 
   it 'creates group with rundeck user in it' do
     expect(windows_chef_run).to create_group('Administrators').with(members: ['rundeck'])

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,3 +7,37 @@ RSpec.configure do |config|
   config.platform = 'centos'
   config.version  = '6.5'
 end
+
+def windows_file_rights_hack
+  # File permissions on Windows depend on RUBY_PLATFORM and we don't want to
+  # change it in Rspec so we include the appropriate modules.
+  # See:
+  # https://github.com/chef/chef/blob/master/lib/chef/mixin/securable.rb#L182
+
+  Chef::Resource::File.send(:include, Chef::Mixin::Securable::WindowsSecurableAttributes)
+  Chef::Resource::File.extend Chef::Mixin::Securable::WindowsMacros
+  Chef::Resource::File.rights_attribute :rights
+  Chef::Resource::File.rights_attribute :deny_rights
+end
+
+def windows_chef_run_with_cert(cert_exist, attributes = {})
+  # Mock file_cache_path
+  allow(Chef::Config).to receive(:[]).and_call_original
+  allow(Chef::Config).to receive(:[]).with('file_cache_path').and_return('')
+
+  # Mock a X509 certificate
+  expect(OpenSSL::X509::Certificate).to receive(:new).and_return double('new certificate', to_der: 'DER_CERT')
+  expect(Digest::SHA1).to receive(:hexdigest).with('DER_CERT').and_return('0123456789ABCDEF')
+
+  # This is used in a guard to import certificate or not.
+  stub_command('Test-Path cert:LocalMachine/Root/0123456789ABCDEF').and_return(cert_exist)
+
+  windows_file_rights_hack
+
+  ChefSpec::SoloRunner.new(WINDOWS_OHAI) do |node|
+    node.set['rundeck_node'] = attributes.merge(
+      user_password_file: 'dummy_file',
+      auth_public_key:    'PUBLIC_KEY_CONTENT'
+    )
+  end.converge described_recipe
+end


### PR DESCRIPTION
Better handling of the Rundeck user password.
- Fix permissions on windows
- Use run_state to share the password between `local_user` and `auth_key` recipes
