### PR TITLE
Set rundeck password file owner to Administrators

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -49,5 +49,5 @@ when 'windows'
   default['rundeck_node']['group']                    = 'Administrators'
   default['rundeck_node']['home']                     = 'C:\ProgramData\rundeck'
   default['rundeck_node']['user_password_file']       = ::File.join(::Chef::Config['file_cache_path'], 'rundeck.pwd')
-  default['rundeck_node']['user_password_file_owner'] = 'SYSTEM'
+  default['rundeck_node']['user_password_file_owner'] = 'Administrators'
 end


### PR DESCRIPTION
Any member of the Administrators group can change a file owner.
=> it's useless to set the owner to SYSTEM only
