### PR TITLE
Avoid rundeck password with trailing backslash

### DIFF
--- a/recipes/local_user.rb
+++ b/recipes/local_user.rb
@@ -33,8 +33,8 @@ if node['rundeck_node']['user_password_file'] && user_pwd.nil?
     # https://technet.microsoft.com/en-us/library/cc786468(v=ws.10).aspx
     # in short: at least 1 uppercase, 1 lowercase, 1 digit, 1 special char
     require 'keepass/password'
-    # winrm-config::service_certmapping does not support password with '"'
-    user_pwd = KeePass::Password.generate('uldsS{26}').gsub('"', '_')
+    # winrm-config::service_certmapping does not support password with '"' or trailing '\'
+    user_pwd = KeePass::Password.generate('uldsS{26}').tr('\"', '*_')
   end
 
   # store the password in run_state for future use


### PR DESCRIPTION
Trailing backslash can be annoying when working with winrm for instance.
So replace it by a star :)

cc. @aboten
