### PR TITLE
Windows auth error

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -32,7 +32,7 @@ default['rundeck_node']['auth']['key']                 = true
 # default['rundeck_node']['auth']['password']            = false
 # default['rundeck_node']['auth']['kerberos']            = false
 
-# Authentication public key
+# Authentication public key - Required for Windows
 default['rundeck_node']['auth_public_key']            = nil
 
 # RunDeck node access configuration depending on OS

--- a/recipes/auth_key.rb
+++ b/recipes/auth_key.rb
@@ -41,6 +41,10 @@ when 'windows'
   require 'openssl'
   require 'digest/sha1'
 
+  unless node['rundeck_node']['auth_public_key']
+    raise 'Attribute auth_public_key is nil! A certificate is needed for Windows platforms.'
+  end
+
   public_key = node['rundeck_node']['auth_public_key']
   public_key_file = ::File.join(Chef::Config['file_cache_path'], 'rundeck.pem')
   thumbprint = Digest::SHA1.hexdigest(OpenSSL::X509::Certificate.new(public_key).to_der).upcase


### PR DESCRIPTION
The cookbook fails on Windows platforms because it requires a certificate. Added error message explaining why the cookbook is failing.

@aboten
