### PR TITLE
Use SSD and delete volume after termination

### DIFF
--- a/.kitchen.ec2.yml
+++ b/.kitchen.ec2.yml
@@ -21,6 +21,11 @@ driver:
   security_group_filter:
     tag:   'Name'
     value: <%= ENV['AWS_SECURITY_GROUP'] || 'chef-testing-opensource-vpc-security-group' %>
+  block_device_mappings:
+    - device_name: /dev/sda1
+      ebs:
+        volume_type: gp2
+        delete_on_termination: true
 
 transport:
   ssh_key: <%= ENV['HOME'] %>/.ssh/id_rsa

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: ruby
 cache: bundler
 rvm:
-- 2.0.0
+- 2.1.0
 sudo: false
 deploy:
   edge: true


### PR DESCRIPTION
The disk volumes are now deleted automatically after terminating instances and general purpose SSDs are used for better performance.

Ruby version was changed to 2.1.0 because chef-zero requires >= 2.1.0
